### PR TITLE
Git 4997 release 4.8 4.9 docs main

### DIFF
--- a/git-integration-for-jira-self-managed/REST-API-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/REST-API-gij-self-managed.md
@@ -12,9 +12,9 @@ Welcome to the Git Integration for Jira app REST API reference page index.
 On this page, you will find the list of available REST APIs supported by the Git Integration for Jira app.  Click on a topic title to view its content or search through the related topics.
 
 <br>
-
-* * *
-
+<br>
+<hr>
+<br>
 <br>
 
 <img src='/wp-content/uploads/gij-bbb-bulkchg-icon.png' width=52 height=39 />

--- a/git-integration-for-jira-self-managed/git-integration-for-jira-home-self-manged.md
+++ b/git-integration-for-jira-self-managed/git-integration-for-jira-home-self-manged.md
@@ -32,13 +32,15 @@ Check out the introduction video and links below to get started with GitKraken C
     <iframe width='709' height='443' src='https://fast.wistia.net/embed/iframe/lr0jp6ntfd?videoFoam=true' frameborder='0' allowfullscreen ></iframe>
 </div> 
 
-<div style='margin-top: 10px; text-align: center'>
+<div style='margin-top: 20px;'>
     Direct links to the above <a href='https://bigbrassband.wistia.com/medias/8c0iq4hwdt'>Getting started</a> video as well as <a href='https://bigbrassband.wistia.com/medias/lr0jp6ntfd'>Installation</a> video.
 </div>
 
-<br>
+&nbsp;
 
 ***
+
+&nbsp;
 
 ## Knowledgebase  
 
@@ -56,7 +58,7 @@ Check out the introduction video and links below to get started with GitKraken C
 
 - [Hooks and Webhooks](/git-integration-for-jira-data-center/hooks-and-webhooks-gij-self-managed) - all about hooks!
 
-- [Product Documentation](/git-integration-for-jira-self-managed/documentation-gij-self-managed)
+- [Product Documentation](/git-integration-for-jira-self-managed/documentation-gij-self-managed) - Learn more about Git Integration for Jira Cloud app and how to easily install it.
 
 <br>
 


### PR DESCRIPTION
REST API page is treated as uncategorized. Will investigate why since the category structure in the file is correct and indented as designed.