### PR TITLE
JMESpath and Custom API Path formatting

### DIFF
--- a/git-integration-for-jira-self-managed/GitHub-App-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/GitHub-App-JMESPath-filter-examples-gij-self-managed.md
@@ -61,33 +61,25 @@ GitHub Apps have different JMESPath format in comparison with previous GitHub in
 
 ## 1\. Starts with
 
-```java
-repositories[] | [?starts_with(name, 'repo-prefix')]
-```
+`repositories[] | [?starts_with(name, 'repo-prefix')]`
 
 Lists repositories with names that starts with the specified word.
 
 ## 2\. Contains (include)
 
-```java
-repositories[] | [?contains(name, 'substring')]
-```
+`repositories[] | [?contains(name, 'substring')]`
 
 Lists repositories with names that contains the specified word.
 
 ## 3\. Contains (exclude)
 
-```java
-repositories[] | [?!contains(name, '<search_phrase>')]
-```
+`repositories[] | [?!contains(name, '<search_phrase>')]`
 
 Lists repositories with names that does not contain the specified word.
 
 ## 4\. Specific (exact)
 
-```java
-repositories[] | [?name == 'exact-repo-name')]
-```
+`repositories[] | [?name == 'exact-repo-name')]`
 
 This is a filter based on the text in the repository name. It will list repositories with names that contain the specified word. Do note that the declared string format is case-sensitive.
 

--- a/git-integration-for-jira-self-managed/GitHub-GitHub-Enterprise-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/GitHub-GitHub-Enterprise-JMESPath-filter-examples-gij-self-managed.md
@@ -17,27 +17,21 @@ An optional JMESPath filter can be configured when adding GitHub integration or 
 
 ## 1\. Contains (include)
 
-```java
-[?contains(name, 'git')]
-```
+`[?contains(name, 'git')]`
 
 This is a filter based on the text in the repository name. It will list repositories with names that contain the word `'git'`. Do note that the declared string format is case-sensitive.
 
 ## 2\. Starts with or ends with
 
-```java
-[?starts_with(name, 'git') | ends_with(name, 'test')]
-```
+`[?starts_with(name, 'git') || ends_with(name, 'test')]`
 
 Lists repositories with names that starts with `'git'` or ends with `'test'`.
 
 ## 3\. Contains (exclude)
 
-```java
-[?(!contains(name, 'firstword'))]
-
-[?(!contains(name, 'firstword')) | (!contains(name, 'secondword'))]
-```
+`[?(!contains(name, 'firstword'))]
+[?(!contains(name, 'firstword')) || (!contains(name, 'secondword'))]
+`
 
 **1** – Lists repositories with names that either do not contain the word `'firstword'`.
 

--- a/git-integration-for-jira-self-managed/Working-with-Custom-API-Path-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Working-with-Custom-API-Path-gij-self-managed.md
@@ -55,17 +55,13 @@ The Custom API Path is called in the integration setup, settings changes, on a r
 
 ### 1\. Lists all repositories (default)
 
-    ```java
-    /user/repos
-    ```
+    `/user/repos`
 
     Gets a list of repositories by the authenticated user. This is the same as when no API path is specified.
 
 ### 2\. Display all repositories from \<username\>
 
-    ```java
-    /users/<username>/repos
-    ```
+    `/users/<username>/repos`
 
     Gets a list of public repositories for the specified user, **\<username\>**.
 
@@ -73,15 +69,11 @@ The Custom API Path is called in the integration setup, settings changes, on a r
 
 ### 3\. Displays starred repositories
 
-    ```java
-    /user/starred
-    ```
+    `/user/starred`
 
     Gets a list of repositories by the authenticated user. This is the same as when no API path is specified.
 
-    ```java
-    /users/<username>/starred
-    ```
+    `/users/<username>/starred`
 
     Gets the list of starred public/private repositories for the specified user, **\<username\>**.
 
@@ -89,18 +81,13 @@ The Custom API Path is called in the integration setup, settings changes, on a r
 
 ### 4\. List all repositories for the specified organization
 
-    ```java
-    /orgs/<org>/repos
-    ```
+    `/orgs/<org>/repos`
 
-    Gets a list of repositories for the specified org, **
-    \<org\>**. _BigBrassBand_
+    Gets a list of repositories for the specified org, **\<org\>**. __GitKraken__
 
     **For instance:**
 
-    ```java
-    /orgs/BigBrassBand/repos
-    ```
+    `/orgs/GitKraken/repos`
 
     This will filter for repositories only within the org: `BigBrassBand`. This works for GitHub integrations.
 
@@ -112,41 +99,31 @@ The Custom API Path is called in the integration setup, settings changes, on a r
 
 ### 1\. Lists all projects (default)
 
-    ```java
-    /api/v4/projects?membership=true
-    ```
+    `/api/v4/projects?membership=true`
 
     Gets a list of projects. This is the same as when no API path is specified.
 
 ### 2\. Display all projects from \<user\_id\>
 
-    ```java
-    /api/v4/users/<user_id>/projects
-    ```
+    `/api/v4/users/<user_id>/projects`
 
-    Gets a list of projects for the specified user, **\<user\_id\>**. _johnsmith_
+    Gets a list of projects for the specified user, **\<user\_id\>**.  __johnsmith__
 
 ### 3\. Displays starred projects
 
-    ```java
-    /api/v4/projects?starred=true
-    ```
+    `/api/v4/projects?starred=true`
 
     Returns GitLab projects that have been starred by the connecting GitLab user.
 
 ### 4\. Limit to owned projects
 
-    ```java
-    /api/v4/projects?owned=true
-    ```
+    `/api/v4/projects?owned=true`
 
     The current user will be limited to the projects it's explicitly owned.
 
 ### 5\. List projects from within a Group
 
-    ```java
-    /api/v4/groups/5245789/projects<br>/api/v4/groups/BigBrassBand/projects
-    ```
+    `/api/v4/groups/5245789/projects<br>/api/v4/groups/BigBrassBand/projects`
 
     Returns the list of repositories within a GitLab Group (or GitLab Subgroup).
     
@@ -154,12 +131,11 @@ The Custom API Path is called in the integration setup, settings changes, on a r
 
 ### 6\. List projects from the specified sub-group
 
-    ```java
-    /api/v4/groups/5245789/projects?include_subgroups=true
-    /api/v4/groups/BigBrassBand/projects?include_subgroups=true
-    ```
+    `/api/v4/groups/5245789/projects?include_subgroups=true
+    /api/v4/groups/GitKraken/projects?include_subgroups=true
+    `
 
-    In the above examples, the `?include_subgroups=true` API extension will return a recursive list of repositories within a nested GitLab Group (or GitLab Subgroup) where the #, `5245789`, is the **Group id**; and `BigBrassBand` is the **Group name**.
+    In the above examples, the `?include_subgroups=true` API extension will return a recursive list of repositories within a nested GitLab Group (or GitLab Subgroup) where the #, `5245789`, is the **Group id**; and `GitKraken` is the **Group name**.
 
 
 For more information on GitLab custom API paths, see <a href='https://docs.gitlab.com/ee/api/' target='_blank'><b>GitLab API</b></a>.


### PR DESCRIPTION
I removed the ```java``` prefix in many of the code sections in JMESPath and Custom API docs. Corrected for GitHub and GitLab. I will review the other documents later.

**Important**: JMESPath allows for pipe (|) operations, which means that you can apply multiple functions to subsequent results. At the same time, it has the OR (||) operator. When writing sub-queries, the OR needs to be added as ||. If using only one pipe character, the validator will render the expression as nonexistent.