### PR TITLE
Removed java syntax highlighting

### DIFF
--- a/git-integration-for-jira-self-managed/Gerrit-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Gerrit-JMESPath-filter-examples-gij-self-managed.md
@@ -17,23 +17,19 @@ An optional JMESPath filter can be configured when adding GitHub integration or 
 
 ## 1. Contains (include)
 
-```java
-[?contains(name, 'git')]
-```
+`[?contains(name, 'git')]`
 
 This is a filter based on the text in the repository name. It will list repositories with names that contain the word `'git'`. Do note that the declared string format is case-sensitive.
 
 ## 2. Starts with or ends with
 
-```java
-[?starts_with(name, 'git') | ends_with(name, 'test')]
-```
+`[?starts_with(name, 'git') | ends_with(name, 'test')]`
 
 Lists repositories with names that starts with `'git'` or ends with `'test'`.
 
 ## 3. Contains (exclude)
 
-```java
+```
 [?(!contains(name, 'firstword'))]
 
 [?(!contains(name, 'firstword')) | (!contains(name, 'secondword'))]
@@ -41,7 +37,7 @@ Lists repositories with names that starts with `'git'` or ends with `'test'`.
 
 **1** – Lists repositories with names that either do not contain the word `'firstword'`.
 
-**2** – Lists repositories with names that either do not contain the words `‘firstword’` OR `‘secondword’`.
+**2** – Lists repositories with names that either do not contain the words `'firstword'` OR `'secondword'`.
 
 The `!condition` must be wrapped in a parenthesis so it won’t invert the whole expression.
 

--- a/git-integration-for-jira-self-managed/GitHub-GitHub-Enterprise-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/GitHub-GitHub-Enterprise-JMESPath-filter-examples-gij-self-managed.md
@@ -29,14 +29,13 @@ Lists repositories with names that starts with `'git'` or ends with `'test'`.
 
 ## 3\. Contains (exclude)
 
-`[?(!contains(name, 'firstword'))]
+`[?(!contains(name, 'firstword'))]`
 
-[?(!contains(name, 'firstword')) || (!contains(name, 'secondword'))]
-`
+`[?(!contains(name, 'firstword')) || (!contains(name, 'secondword'))]`
 
 **1** – Lists repositories with names that either do not contain the word `'firstword'`.
 
-**2** – Lists repositories with names that either do not contain the words `‘firstword’` OR `‘secondword’`.
+**2** – Lists repositories with names that either do not contain the words `'firstword'` OR `'secondword'`.
 
 <br>
 

--- a/git-integration-for-jira-self-managed/GitLab-GitLab-CE-EE-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/GitLab-GitLab-CE-EE-JMESPath-filter-examples-gij-self-managed.md
@@ -17,33 +17,29 @@ An optional JMESPath filter can be configured when adding GitLab integration or 
 
 ## 1\. Contains (include)
 
-```java
-[?contains(name, 'git') | contains(name, 'Slap') | contains(name, 'est')]
-```
+`[?contains(name, 'git') || contains(name, 'Slap') || contains(name, 'est')]`
 
 This is a filter based on the text in the repository name. It will list repositories that contains the specified names. Do note that the declared string format is case-sensitive.
 
 ## 2\. Contains (exclude)
 
-```java
+```
 [?(!contains(tag_list, 'largemedia'))]
 
 [?(!contains(name, 'firstword'))]
 
-[?(!contains(name, 'firstword')) | (!contains(name, 'secondword'))]
+[?(!contains(name, 'firstword')) || (!contains(name, 'secondword'))]
 ```
 
 **1** – Blacklists project tag.
 
 **2** – Lists repositories with names that either do not contain the word `'firstword'`.
 
-**3** – Lists repositories with names that either do not contain the words `‘firstword’` OR `‘secondword’`.
+**3** – Lists repositories with names that either do not contain the words `'firstword'` OR `'secondword'`.
 
 ## 3\. Tags
 
-```java
-[?contains(tag_list, 'largemedia')]
-```
+`[?contains(tag_list, 'largemedia')]`
 
 Whitelists project tag.
 
@@ -63,17 +59,13 @@ Whitelists project tag.
 
 ## 4\. Starts with or ends with
 
-```java
-[?starts_with(name, 'git') | ends_with(name, 'test')]
-```
+`[?starts_with(name, 'git') || ends_with(name, 'test')]`
 
 Lists repositories with names that starts with `'git'` or ends with `'test'`.
 
 ## 5\. Exclude projects without repositories
 
-```java
-[?!empty_repo]
-```
+`[?!empty_repo]`
 
 Lists only repositories from projects that have existing repositories.
 

--- a/git-integration-for-jira-self-managed/Gitolite-integration--why-the-Git-integration-app-not-see-the-master-branch-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Gitolite-integration--why-the-Git-integration-app-not-see-the-master-branch-gij-self-managed.md
@@ -27,7 +27,7 @@ Set the **UMASK** setting as mentioned in [https://stackoverflow.com/questions/1
 
 For gitolite and git repository on the same server as Jira, set the UMASK value in .gitolite.rc file to the following:
 
-```java
+```
 From UMASK => 0077
 To UMASK => 0027
 ```

--- a/git-integration-for-jira-self-managed/Microsoft-VSTS-TFS-Azure-Repos-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Microsoft-VSTS-TFS-Azure-Repos-JMESPath-filter-examples-gij-self-managed.md
@@ -17,31 +17,25 @@ An optional JMESPath filter can be configured when adding Azure Repos integratio
 
 ## 1\. Contains (include)
 
-```java
-value[?contains(name, 'example')] | {value:@}
-```
+`value[?contains(name, 'example')] | {value:@}`
 
 This is a filter based on the text in the repository name. It will list repositories with names containing `'example'`. Do note that the declared string format is case-sensitive.
 
 ## 2\. Contains (exclude)
 
-```java
-value[?(!contains(name, 'Test'))] | {value:@}
-```
+`value[?(!contains(name, 'Test'))] | {value:@}`
 
 The '**!**' expression removes all repositories with `'test'` in the repository name.
 
 ## 3\. Starts with or ends with
 
-```java
-value[?starts_with(name, 'git') | ends_with(name, 'test')] | {value:@}
-```
+`value[?starts_with(name, 'git') | ends_with(name, 'test')] | {value:@}`
 
 Lists repositories with names that starts with `'git'` or ends with `'test'`.
 
 ## Other examples
 
-```java
+```
 value[?contains(project.state, 'wellFormed')] | {value:@}
 
 value[?contains(project.name, 'test2')] | {value:@}

--- a/git-integration-for-jira-self-managed/Tracked-Folders-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Tracked-Folders-JMESPath-filter-examples-gij-self-managed.md
@@ -13,7 +13,7 @@ An optional JMESPath filter can be configured when adding tracked folders.
 
 ## 1\. Contains (include)
 
-```java
+```
 [?contains(name, 'git')]
 ```
 
@@ -21,7 +21,7 @@ Lists repositories with names containing `‘git’`
 
 <br>
 
-```java
+```
 [?contains(name, 'git') | contains(name, 'Slap') | contains(name, 'est')]
 ```
 
@@ -29,7 +29,7 @@ Lists all the repositories that contain the specified names. |
 
 ## 2\. Contains (exclude)
 
-```java
+```
 [?(!contains(name, 'firstword'))]
 
 [?(!contains(name, 'firstword')) | (!contains(name, 'secondword'))]
@@ -43,7 +43,7 @@ Lists all the repositories that contain the specified names. |
 
 The example below ONLY works for tracked folder integration; where it supports the ‘`fullPath`’ field:
 
-```java
+```
 [?!starts_with(fullPath, '/home/user/local/store/private-repos')]
 ```
 


### PR DESCRIPTION
Apparently our documentation site does not support extended code block syntax highlighting. Removed them.