### PR TITLE
Fixed logic in contains (exclude) examples

### DIFF
--- a/git-integration-for-jira-self-managed/Gerrit-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Gerrit-JMESPath-filter-examples-gij-self-managed.md
@@ -32,7 +32,7 @@ Lists repositories with names that starts with `'git'` or ends with `'test'`.
 ```
 [?(!contains(name, 'firstword'))]
 
-[?(!contains(name, 'firstword')) || (!contains(name, 'secondword'))]
+[?(!contains(name, 'firstword')) && (!contains(name, 'secondword'))]
 ```
 
 **1** – Lists repositories with names that either do not contain the word `'firstword'`.

--- a/git-integration-for-jira-self-managed/GitHub-GitHub-Enterprise-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/GitHub-GitHub-Enterprise-JMESPath-filter-examples-gij-self-managed.md
@@ -31,7 +31,7 @@ Lists repositories with names that starts with `'git'` or ends with `'test'`.
 
 `[?(!contains(name, 'firstword'))]`
 
-`[?(!contains(name, 'firstword')) || (!contains(name, 'secondword'))]`
+`[?(!contains(name, 'firstword')) && (!contains(name, 'secondword'))]`
 
 **1** – Lists repositories with names that either do not contain the word `'firstword'`.
 

--- a/git-integration-for-jira-self-managed/GitLab-GitLab-CE-EE-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/GitLab-GitLab-CE-EE-JMESPath-filter-examples-gij-self-managed.md
@@ -28,7 +28,7 @@ This is a filter based on the text in the repository name. It will list reposito
 
 [?(!contains(name, 'firstword'))]
 
-[?(!contains(name, 'firstword')) || (!contains(name, 'secondword'))]
+[?(!contains(name, 'firstword')) && (!contains(name, 'secondword'))]
 ```
 
 **1** – Blacklists project tag.

--- a/git-integration-for-jira-self-managed/Tracked-Folders-JMESPath-filter-examples-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Tracked-Folders-JMESPath-filter-examples-gij-self-managed.md
@@ -32,7 +32,7 @@ Lists all the repositories that contain the specified names.
 ```
 [?(!contains(name, 'firstword'))]
 
-[?(!contains(name, 'firstword')) || (!contains(name, 'secondword'))]
+[?(!contains(name, 'firstword')) && (!contains(name, 'secondword'))]
 ```
 
 **1** – Lists repositories with names that either do not contain the word `'firstword'`.


### PR DESCRIPTION
For the exclude logic, when multiple conditions are added, the operator needs to be AND (&&). If using OR (||) the conditions override each other.