### PR TITLE
GIT-5556 Add simple instruction on downloading the actual file

### DIFF
--- a/git-integration-for-jira-self-managed/Bulk-Change-API-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Bulk-Change-API-gij-self-managed.md
@@ -13,7 +13,7 @@ To use the API, users must:
 
 *   install the <a href='http://docs.python-requests.org/en/latest/user/install/#install' target='_blank'><b>Requests »</b></a> Python package.
 
-*   declare `JIRA_BASE`, `JIRA_USER`, and `JIRA_PASSWORD` in the `configuration_conf.py` file.  The `JIRA_USER` defined in this file must have Jira Admin global permissions.  _(Download_ <a href='/wp-content/uploads/configuration_conf.zip'>sample file ↓</b></a> _as a zip file.)_
+*   declare `JIRA_BASE`, `JIRA_USER`, and `JIRA_PASSWORD` in the `configuration_conf.py` file.  The `JIRA_USER` defined in this file must have Jira Admin global permissions.  _(Download by right-clicking the file then save_ <a href='/wp-content/uploads/configuration_conf.zip'>sample file ↓</b></a> _as a zip file.)_
 
 
 HTTP Status code response:

--- a/git-integration-for-jira-self-managed/Bulk-Export-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Bulk-Export-gij-self-managed.md
@@ -26,6 +26,7 @@ GET
     </div>
     <div class="imsgbox">
         <b><i>Download sample file</i></b><br>
+        Right click the link and save it somewhere accessible:<br>
         <a href='/wp-content/uploads/configuration_get.zip'><b>configuration_get.py</b></a>
     </div>
     </div>

--- a/git-integration-for-jira-self-managed/Bulk-Import-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Bulk-Import-gij-self-managed.md
@@ -65,6 +65,7 @@ Returns the ID of the importing thread.
 <br>
 
 _**Download sample file**_<br>
+Right click and save the file below then extract to an easily accessible folder:<br>
 [**configuration\_post.py**](/wp-content/uploads/configuration_post.zip)
 
 &nbsp;

--- a/git-integration-for-jira-self-managed/Commit-msg-Hook-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Commit-msg-Hook-gij-self-managed.md
@@ -29,7 +29,7 @@ Example: `re.compile(r'\[(\w+7-\d+?)\]')`
 
 In Linux and OSX, this file must have executable permissions in the file system; in Windows, setting this permission is not necessary.  To use the hook in Windows without python installed, see <a href='https://docs.python.org/2/faq/windows.html#how-do-i-make-an-executable-from-a-python-script' target='_blank'><b>Python on Windows FAQ »</b></a>.
 
-See the commit-msg hook code on the right panel or download the sample **[commit-msg file ↓](/wp-content/uploads/commit-msg.zip)**, make the necessary changes, and place it in the required folder.
+See the commit-msg hook script below or right click and download the sample **[commit-msg file ↓](/wp-content/uploads/commit-msg.zip)**. Extract this file and make the necessary changes. Afterwards, place the edited file to the required folder (usually in .git/hooks directory).
 
 <div class="bbb-callout bbb--info">
     <div class="irow">

--- a/git-integration-for-jira-self-managed/Get-Bulk-Import-Information-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Get-Bulk-Import-Information-gij-self-managed.md
@@ -31,6 +31,7 @@ Returns the status information of the import process.
 
 ### Download sample file
 
+Right click the link and download the file below:
 [**configuration\_progress.py**](/wp-content/uploads/configuration_progress.zip)
 
 * * *

--- a/git-integration-for-jira-self-managed/Server-side-Hook-gij-self-managed.md
+++ b/git-integration-for-jira-self-managed/Server-side-Hook-gij-self-managed.md
@@ -48,7 +48,7 @@ The **pre-receive** server-side hook requires git administrators to:
 </div>
 <br>
 
-See the server-side hook script on the right panel or download the sample **[pre-receive file ↓](/wp-content/uploads/pre-receive.zip)** – make the necessary changes, and place it in the required folder.
+See the server-side hook script below or right click and download the sample **[pre-receive file ↓](/wp-content/uploads/pre-receive.zip)**. Extract this file and make the necessary changes. Afterwards, place the edited file to the required folder (usually in .git/hooks directory).
 
 <div class="bbb-callout bbb--error">
     <div class="irow">


### PR DESCRIPTION
At first I thought the plugin didn't upload the zip files to the HC upload folder. Upon checking, it's really there. It's just the GK HC seems to try to open the zip file within the browser.